### PR TITLE
Resolves Issue:41 by adding additional behaviours: assoc-in, update-in, merge and merge-with

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ previous reference documentation, visit the
 
 | Version             | Notes
 |---------------------|------------------------------------------------------
+| 3.6.1-v1.0-SNAPSHOT | Adds additional Persistent Map behaviours: `assoc-in`, `update-in`, `merge` and `merge-with` to `protobuf.impl.flatland.core.FlatlandProtoBuf` and `protobuf.PersistentProtocolBufferMap` allowing users to work with constructed objects as if they were normal maps. Also resolves [Issue #41](https://github.com/clojusc/protobuf/issues/41)
 | 3.6.0-v1.2-SNAPSHOT | Bumped to latest release of protobuf-java (see the branch [release/1.2.x](https://github.com/clojusc/protobuf/tree/release/1.2.x)), added byte and stream support in constructors, added benchmarking
 | 3.5.1-v1.1          | Added docs, more func renames, new abstraction layer, improved DevEx of API, and fix for enums as Clojure keywords
 | 3.5.1-v1.0          | Droped extra deps, renamed functions

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojusc/protobuf "3.6.0-v1.2-SNAPSHOT"
+(defproject clojusc/protobuf "3.6.1-v1.2-SNAPSHOT"
   :description "A Clojure interface to Google's protocol buffers"
   :url "https://github.com/clojusc/protobuf"
   :license {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojusc/protobuf "3.6.1-v1.2-SNAPSHOT"
+(defproject clojusc/protobuf "3.6.1-v1.0-SNAPSHOT"
   :description "A Clojure interface to Google's protocol buffers"
   :url "https://github.com/clojusc/protobuf"
   :license {

--- a/src/clj/protobuf/common.clj
+++ b/src/clj/protobuf/common.clj
@@ -56,3 +56,17 @@
 
 (def seqable-behaviour
   {:seq (fn [this] (.seq (get-instance this)))})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;   Additional Map Behaviours   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def additional-persistent-map-behaviours
+  {:assoc-in (fn [protobuf-object ks v]
+               (assoc-in protobuf-object ks v))
+   :update-in (fn [protobuf-object ks fn]
+                (update-in protobuf-object ks fn))
+   :merge (fn [& protobuf-objects]
+            (merge (first protobuf-objects)))
+   :merge-with (fn [fn & protobuf-objects]
+                 (merge-with fn (first protobuf-objects)))})

--- a/src/clj/protobuf/core.clj
+++ b/src/clj/protobuf/core.clj
@@ -4,8 +4,16 @@
     [protobuf.common :as common]
     [protobuf.impl.flatland.core :as flatland])
   (:import
-    (protobuf.impl.flatland.core FlatlandProtoBuf))
-  (:refer-clojure :exclude [map? read]))
+    (protobuf.impl.flatland.core FlatlandProtoBuf)
+    (protobuf PersistentProtocolBufferMap))
+  (:refer-clojure :exclude [map? read assoc-in update-in merge merge-with]))
+
+(defprotocol AdditionalPersistentMapAPI
+  (assoc-in [protobuf-object ks v])
+  (update-in [protobuf-object ks fn])
+  (merge [& protobuf-objects])
+  (merge-with [fn & protobuf-objects]))
+
 
 (defprotocol ProtoBufCommonAPI
   (get-class [this])
@@ -27,6 +35,14 @@
 (extend FlatlandProtoBuf
         ProtoBufAPI
         flatland/behaviour)
+
+(extend FlatlandProtoBuf
+  AdditionalPersistentMapAPI
+  common/additional-persistent-map-behaviours)
+
+(extend PersistentProtocolBufferMap
+  AdditionalPersistentMapAPI
+  common/additional-persistent-map-behaviours)
 
 (def default-impl-name "flatland")
 


### PR DESCRIPTION
This PR resolves #41 and  :
- Adds additional Persistent Map behaviours: `assoc-in`, `update-in`, `merge` and `merge-with` to `protobuf.impl.flatland.core.FlatlandProtoBuf` and `protobuf.PersistentProtocolBufferMap` allowing users to work with constructed objects as if they were regular Clojure maps.
- Updates version to 3.6.1-v1.0-SNAPSHOT

 